### PR TITLE
updated the api url to include forecast parameter

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -1,6 +1,6 @@
 const currentTime = dayjs();
 const searchForm = $('#search-form');
-const cities = ['Denver', 'Chicago', 'Seattle', 'New York', 'Boise', 'Idaho Falls', 'Boulder', 'Littleton', 'Colorado Springs', 'Estes Park', 'Winter Park', 'Fraiser']
+const autoCompleteList = ['Denver', 'Granville', 'Chicago', 'Seattle', 'New York', 'Boise', 'Idaho Falls', 'Boulder', 'Littleton', 'Colorado Springs', 'Estes Park', 'Winter Park', 'Fraiser']
 // const searchForm = document.getElementById('search-form');
 
 const searchInput = $('#city-input');
@@ -30,7 +30,7 @@ searchForm.on('submit', function (e) {
 // })
 
 getWeather = (city) => {
-    fetch(`https://api.openweathermap.org/data/2.5/weather?q=${city}&appid=a65fbee006d1cdf010afb7d2f7201d89`)
+    fetch(`https://api.openweathermap.org/data/2.5/forecast?q=${city}&appid=a65fbee006d1cdf010afb7d2f7201d89`)
         .then(function (response) {
             console.log(response);
             return response.json();
@@ -49,11 +49,11 @@ getWeather = (city) => {
 // This function adds an autocomplete menu for various cities using the jQuery UI.
 $(function () {
     $('#city-input').autocomplete({
-        source: cities,
+        source: autoCompleteList,
     })
 });
 
 // This would allow for a sortable list of cities.
-$(function () {
-    $("#city-list").sortable();
-});
+// $(function () {
+//     $("#city-list").sortable();
+// });

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
         <form action="https://api.openweathermap.org/data/2.5/weather?" id="search-form">
             <label for="city-input">Search for a City:</label>
             <input type="search" placeholder="City" id="city-input" name="q">
-            <button id="serach-btn">Search</button>
+            <button id="search-btn">Search</button>
         </form>
 
         <div class="list-group" id="city-list">


### PR DESCRIPTION
This PR adds several small updates and corrections to the application.  The url of the Open Weather API was updated to include the forecast parameter instead of weather.  This provides the full data set requested by the client.  An additional location, Granville, was added to the list of cities available in the autocomplete list.  The name of the variable used to store the autocomplete list was also updated to autoCompleteList to more easily identify its purpose and provide for enhanced legibility in the future.  Finally, the id name of the search button was corrected.  It was misspelled on entry.


https://openweathermap.org/forecast5 