### PR TITLE
further updated bootstrap classes and styles

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -49,9 +49,9 @@ button {
     border-radius: .5em;
 }
 
-#forecast-row {
+/* #forecast-row {
     flex-wrap: nowrap;
-}
+} */
 
 /* ul{
     width: 10%;

--- a/index.html
+++ b/index.html
@@ -33,9 +33,14 @@
     </header>
 
     <main id="main">
+        <!-- The container fluid class had to be added here to allow the content to display across the full width of the viewport. -->
         <div class="container-fluid m-0" id="container1">
-            <div class="row" id="forecast-row">
-                <ul class="list-group mt-3 col-2" id="city-list">
+
+            <!-- No wrap was set on the row to allow both the list and the buttons to display within the same line on medium screens and above.  On smaller screens the elements will wrap to a new line. -->
+            <div class="row flex-md-nowrap" id="forecast-row">
+
+                <!-- The columns were set to use medium two here to set them to only two columns on screens medium size and above.  On smaller screens it will break to display the full width of the screen. -->
+                <ul class="list-group mt-3 col-md-2" id="city-list">
                     <button type="button" class="list-group-item list-group-item-action mb-2 text-center">
                         City 1
                     </button>


### PR DESCRIPTION
This PR updates the bootstrap classes on the row elements.  The no-wrap property set within the CSS used to test the layout was removed, and the properties were set directly on the forecast-row element to allow for more control of responsiveness.   The properties are set to display with no-wrap on medium screens and above.  Smaller screens will wrap the list and forecast elements to a new line.  The column property on the list element was also updated to display using only two columns on medium and above, allowing the full width on smaller screens for a better viewing experience.