### PR TITLE
updated list listener to save cities searched

### DIFF
--- a/assets/scripts/script.js
+++ b/assets/scripts/script.js
@@ -26,6 +26,8 @@ searchForm.on('submit', function (e) {
     // This will add the searched cities to an array that holds previously searched values.  The array will be used to write the values to the list item buttons.
     searchedCities.push(inputCity);
     // displayForecast(getWeather);
+
+    createCityButtons();
     
     // This clears the input field after searching.
     searchInput.val('');
@@ -58,6 +60,27 @@ getWeather = (city) => {
 //     console.log(data);
 // }
 
+// To make this work an array will be needed.  It will start empty and need to be written to local storage.  The basic functionality has been tested and does work.  The array's values are updated with a push of the search input in the submit form's event listener.
+const cityList = $('#city-list');
+const searchedCities = [];
+
+createCityButtons = () => {
+for (let i=0; i < cityList[0].children.length; i++) {
+    cityList[0].children[i].innerText = searchedCities[i]
+}
+};
+
+
+// The idea of this listener is extremely important. The listener is added to the parent ul element and listens for events on buttons that are children.  It takes advantage of the concept of event bubbling and eliminates what would be repetitious code to add listeners to all buttons.  This allows for dynamic creation of button elements within this parent and will automatically listen on elements added.  This will be used to recall forecast data related to cities previously searched.  It's important to remember it's an array of objects and requires the index to use the listener without an error.
+cityList[0].addEventListener('click', function(e) {
+       if (e.target.tagName === 'BUTTON') {
+        console.log(e.target.innerText);
+
+        // This calls the same getWeather function defined earlier to be used within the submit form listener.  The function was designed for resuse by adding the city argument.  That arguemnt is what allows the event target's inner text to be passed to the API call here.
+        getWeather(e.target.innerText);
+    }
+});
+
 
 displayForecast = (fnc) => {
     fnc();
@@ -77,23 +100,3 @@ $(function () {
 // $(function () {
 //     $("#city-list").sortable();
 // });
-
-
-// To make this work an array will probably be needed.  It will start empty and need to be written to local storage.  The basic functionality has been tested and does work.  
-const cityList = $('#city-list');
-const searchedCities = [];
-
-createCityButtons = () => {
-for (let i=0; i < cityList[0].children.length; i++) {
-    // cityList[0].children[i].innerText = searchedCities[i]
-}
-};
-
-
-// The idea of this listener is extremely important. The listener is added to the parent ul element and listens for events on buttons that are children.  It takes advantage of the concept of event bubbling and eliminates what would be repetitious code to add listeners to all buttons.  This allows for dynamic creation of button elements within this parent and will automatically listen on elements added.  This will be used to recall forecast data related to cities previously searched.  It's important to remember it's an array of objects and requires the index to use the listener without an error.
-cityList[0].addEventListener('click', function(e) {
-   
-    if (e.target.tagName === 'BUTTON') {
-        console.log(e.target.innerText);
-    }
-});


### PR DESCRIPTION
This PR updates the cityList event listener to add the city searched for to a button within the list.  The event listener was defined on the ul parent element in a previous PR.  This PR simply used the previously defined listener and added the getWeather function to it.  The getWeather function was designed for reuse by adding the city argument.  That argument is what allows the event target's inner text to be passed to the API call here.  Reusing the getWeather function will retrieve the forecast for the city displayed when clicked due to the listener.

The createCityButtons function looks at the searchedCities array.  The array is initially defined as an empty array.  Search values are pushed to this array within the submit form event listener.  This creates a new entry in the array each time a city is searched.  The createCityButtons functions is called within the form's submit event after the array has been updated.  This is what writes the city name to a button.  

Decisions need to be made related to the application's functionality and how many saved entries will be allowed.