### PR TITLE
changed flex properties of forecast cards

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -9,8 +9,8 @@
     --color7: #1A759F;
     --color8: #1E6091;
     --color9: #184E77;
-    --gradient1: linear-gradient(0.25turn, #34A0A4, #99D98C, #1A759F);
-    --gradient2: linear-gradient(0.25turn, #99D98C, #34A0A4, #B5E48C);
+    --gradientDark: linear-gradient(0.25turn, #1E6091, #99D98C, #1A759F);
+    --gradientLight: linear-gradient(0.25turn, #99D98C, #34A0A4, #B5E48C);
 }
 
 *{
@@ -51,14 +51,14 @@ h1 {
 h2 {
     text-align: center;
     /* background-color: var(--color7); */
-    background: var(--gradient1);
+    background: var(--gradientDark);
     /* color: white; */
     border-radius: .5em;
 }
 
 h3 {
     /* background-color: var(--color1); */
-    background: var(--gradient2);
+    background: var(--gradientLight);
     border-radius: .5em;
     margin-top: 10px;
 }
@@ -81,8 +81,12 @@ label {
 
 button {
     border-radius: .8em;
-    background: var(--gradient2);
+    background: var(--gradientLight);
     font-weight: bold;
+}
+
+#search-btn {
+    background: var(--gradientDark);
     color: white;
 }
 
@@ -123,12 +127,17 @@ button {
     font-size: 2rem;
 }
 
+#extended-forecast .card {
+    background-color: white;
+}
+
 @media screen and (max-width: 750px) {
-    #extended-forecast .future {
-        margin-left: 50px;
-        
+    #extended-forecast .card {
+        margin-left: 20px;   
     }
 }
+
+
 /* #forecast-row {
     flex-wrap: nowrap;
 } */

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <meta name="author" content="Cody Burkholder" />
+    <meta name="author" content="Cody Burkholder">
 
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css" rel="stylesheet"
         integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
@@ -59,7 +59,7 @@
                         <!-- <h2 class="city-name text-center">Name of City</h2> -->
                         <!-- The width property is needed here to work with the container fluid property that allows the content to stretch across the screen, but overflows the area.  This limits the element to make it display on screen. -->
                         <div class="row p-4 min-vw-75">
-                            <div class="col text-center forecast-card" id="display-current-weather">
+                            <div class="col-lg-8 text-center forecast-card" id="display-current-weather">
                                 <!-- A card was inserted into the container -->
                                 <!-- The size of this card was changed from the default of 18rem to make the current weather display larger. -->
                                 <div class="card" >
@@ -91,7 +91,7 @@
 
             <section id="extended-forecast">
                 <h2>Extended Forecast</h2>
-                <div class="row justify-content-center-lg">
+                <div class="row justify-content-lg-center">
                     <div class="col-xl-2 col-md-6 text-center future" id="day1">
                         <!-- Card 2 inserted here -->
                         <div class="card" style="width: 18rem;">


### PR DESCRIPTION
This PR adjusts the flex properties of the forecast cards, both current and extended.  The columns specified for the current forecast's grid were changed to 8 for large viewports.  This keeps the display contained within the view.  Setting the large parameter allows it to use the full space available in the grid on smaller viewports.  The justify properties of the extended forecast cards were also changed to only center on large viewports.  This allows elements that are wrapped to display in a more user friendly layout on smaller screens.